### PR TITLE
Fixes deprecate type constraint

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "host" {
 }
 
 variable "alternates" {
-    type = "list"
+    type = list
     default = []
 }
 


### PR DESCRIPTION
TL;DR
-----

Confirms all type constraints use unquoted syntax

Details
-------

This module had one remaining type contraint on the variable
`alternates` that use the pre-Terraform 0.12 syntax with the type
contraint quoted. This fix changes it so the module is free of
deprecated type constraint syntax.