### PR TITLE
Doesn't call deprecate `list()`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "tls_cert_request" "request" {
 
   key_algorithm   = "RSA"
   private_key_pem = tls_private_key.certificate_key.private_key_pem
-  dns_names = concat(list(var.host),var.alternates)
+  dns_names = concat(tolist(var.host),var.alternates)
 
   subject {
     common_name = var.host


### PR DESCRIPTION
TL;DR
-----

Updates the use of `list()` (which is removed) to `tolist()`

Details
-------

I'd been using `list()` to create a list from a string in spite of
the deprecation warnings because I liked the way my code read when
I did. It caught up with me, because that capability was removed.

This change fixes the bug that created, and uses the `tolist()`
function instead.
