### PR TITLE
Fixes bad use of `tolist()`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ resource "tls_cert_request" "request" {
 
   key_algorithm   = "RSA"
   private_key_pem = tls_private_key.certificate_key.private_key_pem
-  dns_names = concat(tolist(var.host),var.alternates)
+  dns_names = concat( [ var.host ],var.alternates)
 
   subject {
     common_name = var.host


### PR DESCRIPTION
TL;DR
-----

Replaces use of `tolist()` in previous change with a literal

Details
-------

I jumped the gun on the previous fix by assuming I could use the
`tolist()` function in the same way as list, but that wasn't the
case. This new fix uses a literal list.
